### PR TITLE
Use 5.3 snapshots as the recommended version in `README.md`

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -15,13 +15,13 @@ You can install latest toolchain of SwiftWasm from [Release Page](https://github
 
 The toolchains can be installed via [`swiftenv`](https://github.com/kylef/swiftenv) like official nightly toolchain.
 
-e.g.
+Here's an example `swiftenv` invocation for installing the latest stable SwiftWasm toolchain on macOS Catalina:
 ```sh
 
 $ swiftenv install \
-  https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2020-06-07-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2020-06-07-a-osx.tar.gz
+  https://github.com/swiftwasm/swift/releases/download/swift-wasm-5.3-SNAPSHOT-2020-08-15-a/swift-wasm-5.3-SNAPSHOT-2020-08-15-a-osx.tar.gz
 $ swift --version
-Swift version 5.3-dev (LLVM 7fc8796bc1, Swift 5be35e7aee)
+Swift version 5.3-dev (LLVM ba56ef042e, Swift 5855a96018)
 Target: x86_64-apple-darwin19.3.0
 ```
 


### PR DESCRIPTION
5.3 snapshots are more stable and allow depending on JavaScriptKit using package versions instead of revisions (due to the changes I applied in the 5.3 branch).

Also, runtime metadata differs between 5.3 and development snapshots, where development snapshots no longer contain dummy Objective-C fields (even if those are unused) on non-Apple platforms. The [Runtime library I maintain](https://github.com/MaxDesiatov/Runtime), and which we use in [Tokamak](https://tokamak.dev) currently relies on the metadata layout used in 5.3 snapshots. I'm afraid some people may start using Tokamak with development snapshots with incompatible metadata layout, which could lead to issues which are hard to diagnose.