### PR TITLE
Stop referring to the master branch, refine wording

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -12,7 +12,7 @@
     - [Exporting function](examples/exporting-function.md)
     - [Example Projects](examples/example-projects.md)
 - [Contribution Guide](contribution-guide/index.md)
-    - [How to build toolchain](contribution-guide/how-to-build-toolchain.md)
+    - [How to build the toolchain](contribution-guide/how-to-build-toolchain.md)
     - [Continuous Integration](contribution-guide/continuous-integration.md)
     - [Tips](contribution-guide/tips.md)
 

--- a/src/contribution-guide/how-to-build-toolchain.md
+++ b/src/contribution-guide/how-to-build-toolchain.md
@@ -23,7 +23,7 @@ $ ./utils/webassembly/linux/install-dependencies.sh
 
 ## 3. Build using custom preset options
 
-We support both Linux and macOS to build Swift. You need to select the preset name, [`sccache`](./cache.md) path and LLVM tools directory.
+We support both Linux and macOS to build Swift. You need to select the preset name, `sccache` path and LLVM tools directory.
 
 
 ```sh

--- a/src/contribution-guide/index.md
+++ b/src/contribution-guide/index.md
@@ -13,30 +13,61 @@ The main repository of this project. Forked from [apple/swift](https://github.co
 
 #### Branching scheme
 
-- `swiftwasm` is the main develop branch
-- `master` is a mirror of the `master` branch of the upstream `apple/master` repository. This branch is necessary to avoid [some issues](https://github.com/swiftwasm/swift/pull/36)
+- `swiftwasm` is the main development branch.
+- `main` is a mirror of the `main` branch of the upstream `apple/swift` repository. This branch is necessary to avoid [some issues](https://github.com/swiftwasm/swift/pull/36).
 - `swiftwasm-release/5.3` is the branch where 5.3 release of SwiftWasm is prepared.
 - `release/5.3` is a mirror of the upstream `release/5.3` branch.
 
 ### [swiftwasm/llvm-project](https://github.com/swiftwasm/llvm-project)
 
-Forked from [apple/llvm-project](https://github.com/apple/llvm-project).
+This repository is a fork of [apple/llvm-project](https://github.com/apple/llvm-project).
 
-`swiftwasm` branch is based on `swift/master` branch of `apple/llvm-project`.
+`swiftwasm` branch is based on `swift/main` branch of `apple/llvm-project`.
 
-Please see [AppleBranchingScheme.md](https://github.com/apple/llvm-project/blob/apple/master/apple-docs/AppleBranchingScheme.md)
+Please see the [AppleBranchingScheme.md](https://github.com/apple/llvm-project/blob/apple/main/apple-docs/AppleBranchingScheme.md)
+document in the upstream repository for more details.
 
 
 ### [swiftwasm/icu4c-wasi](https://github.com/swiftwasm/icu4c-wasi)
 
-Build script and patches for building ICU project for WebAssembly
-
-We are sending patches to upstream repository.
-
-- https://github.com/unicode-org/icu/pull/990
+Build script and patches for building ICU project for WebAssembly. [The required changes to build 
+it](https://github.com/unicode-org/icu/pull/990) were merged to the upstream repository.
 
 ### [swiftwasm/wasi-sdk](https://github.com/swiftwasm/wasi-sdk) and [swiftwasm/wasi-libc](https://github.com/swiftwasm/wasi-libc)
 
 Forked from [WebAssembly/wasi-sdk](https://github.com/WebAssembly/wasi-sdk) and [WebAssembly/wasi-libc](https://github.com/WebAssembly/wasi-libc).
 
 We fork them to build `wasi-sysroot` with pthread header. There aren't so many diff from upstream.
+
+## How to build
+
+Check out the project source code and run the `ci.sh` script, which will install the dependencies,
+and then run the build and tests.
+
+```sh
+$ mkdir swiftwasm-source
+$ cd swiftwasm-source
+$ git clone https://github.com/swiftwasm/swift.git
+$ ./swift/utils/webassembly/ci.sh
+```
+
+If you want to get more information about the build system, please feel free to ask 
+[@kateinoigakukun](https://twitter.com/kateinoigakukun) or
+[@MaxDesiatov](https://twitter.com/MaxDesiatov) on Twitter.
+
+## Development Tips
+
+### Cache
+
+Compilation time of LLVM project is very long, so we recommend to cache build results with `sccache`.
+Our `ci.sh` script does this automatically for you, and uses the `build-cache` subdirectory as a build
+cache. The upstream `swift` repository provides [an introductory guide to `sccache`
+usage]https://github.com/apple/swift/blob/main/docs/DevelopmentTips.md#use-sccache-to-cache-build-artifacts)
+if you'd like to use it manually.
+
+### Debugging
+
+When you want to debug a WebAssembly binary, [wasminspect](https://github.com/kateinoigakukun/wasminspect) 
+can help in the investigation if the debugged binary does not rely on integration with JavaScript.
+We recommend splitting your packages into separate executable targets, most of which shouldn't 
+assume the availability of JavaScript to make debugging easier.

--- a/src/contribution-guide/index.md
+++ b/src/contribution-guide/index.md
@@ -38,36 +38,3 @@ it](https://github.com/unicode-org/icu/pull/990) were merged to the upstream rep
 Forked from [WebAssembly/wasi-sdk](https://github.com/WebAssembly/wasi-sdk) and [WebAssembly/wasi-libc](https://github.com/WebAssembly/wasi-libc).
 
 We fork them to build `wasi-sysroot` with pthread header. There aren't so many diff from upstream.
-
-## How to build
-
-Check out the project source code and run the `ci.sh` script, which will install the dependencies,
-and then run the build and tests.
-
-```sh
-$ mkdir swiftwasm-source
-$ cd swiftwasm-source
-$ git clone https://github.com/swiftwasm/swift.git
-$ ./swift/utils/webassembly/ci.sh
-```
-
-If you want to get more information about the build system, please feel free to ask 
-[@kateinoigakukun](https://twitter.com/kateinoigakukun) or
-[@MaxDesiatov](https://twitter.com/MaxDesiatov) on Twitter.
-
-## Development Tips
-
-### Cache
-
-Compilation time of LLVM project is very long, so we recommend to cache build results with `sccache`.
-Our `ci.sh` script does this automatically for you, and uses the `build-cache` subdirectory as a build
-cache. The upstream `swift` repository provides [an introductory guide to `sccache`
-usage]https://github.com/apple/swift/blob/main/docs/DevelopmentTips.md#use-sccache-to-cache-build-artifacts)
-if you'd like to use it manually.
-
-### Debugging
-
-When you want to debug a WebAssembly binary, [wasminspect](https://github.com/kateinoigakukun/wasminspect) 
-can help in the investigation if the debugged binary does not rely on integration with JavaScript.
-We recommend splitting your packages into separate executable targets, most of which shouldn't 
-assume the availability of JavaScript to make debugging easier.

--- a/src/contribution-guide/tips.md
+++ b/src/contribution-guide/tips.md
@@ -27,6 +27,9 @@ Compilation time of LLVM and the Swift toolchain is very long, so we recommend t
 
 ## Debugging
 
-When you want to debug a WebAssembly binary, [wasminspect](https://github.com/kateinoigakukun/wasminspect) is very helpful to investigate.
+When you want to debug a WebAssembly binary, [wasminspect](https://github.com/kateinoigakukun/wasminspect) 
+can help in the investigation if the debugged binary does not rely on integration with JavaScript.
+We recommend splitting your packages into separate executable targets, most of which shouldn't 
+assume the availability of JavaScript to make debugging easier.
 
 ![demo](https://raw.githubusercontent.com/kateinoigakukun/wasminspect/master/assets/demo.gif)


### PR DESCRIPTION
The `master` branch no longer exists in upstream Apple's repositories.