### PR TITLE
Point to the table of contents from the README

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,8 @@
 # Introduction
 
-Welcome to the SwiftWasm Documentation! To get started visit the [table of contents](./SUMMARY.md).
+Welcome to the SwiftWasm Documentation! 
+
+To get started visit the [table of contents](./SUMMARY.md), or the compiled docs at [book.swiftwasm.org](book.swiftwasm.org).
 
 [SwiftWasm is an open source project to support the WebAssembly target for Swift.](https://github.com/swiftwasm)
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Welcome to the SwiftWasm Documentation!
+Welcome to the SwiftWasm Documentation! To get started visit the [table of contents](./SUMMARY.md).
 
 [SwiftWasm is an open source project to support the WebAssembly target for Swift.](https://github.com/swiftwasm)
 


### PR DESCRIPTION
 This makes it clear that a user doesn't need to clone this and build it to read it.